### PR TITLE
Update connection count logic

### DIFF
--- a/check-rabbitmq-exchange.cabal
+++ b/check-rabbitmq-exchange.cabal
@@ -1,5 +1,5 @@
 name:                check-rabbitmq-exchange
-version:             0.1.0
+version:             0.2.0
 synopsis:            Simple NRPE-based Nagios check for the length of a RabbitMQ queue
 description:         Simple NRPE-based Nagios check for the length of a RabbitMQ queue
 homepage:            https://github.com/anchor/haskell-nagios-checks

--- a/check-rabbitmq-exchange.cabal
+++ b/check-rabbitmq-exchange.cabal
@@ -23,6 +23,7 @@ library
   build-depends:     base >=4.5 && <4.8,
                      aeson,
                      optparse-applicative,
+                     vector,
                      bytestring,
                      text,
                      nagios-check

--- a/check-rabbitmq-exchange.cabal
+++ b/check-rabbitmq-exchange.cabal
@@ -7,10 +7,8 @@ license:             BSD3
 license-file:        LICENSE
 author:              Anchor Engineering <engineering@anchor.com.au>
 maintainer:          Anchor Engineering <engineering@anchor.com.au>
--- copyright:
 category:            Testing
 build-type:          Simple
--- extra-source-files:
 cabal-version:       >=1.10
 
 

--- a/lib/Nagios/Check/RabbitMQ/Options.hs
+++ b/lib/Nagios/Check/RabbitMQ/Options.hs
@@ -34,6 +34,10 @@ checkOptions = CheckOptions
         <> short 'R'
         <> metavar "MAXIMUM_RATE" )))
     <*> (minThreshold <$> optional ( option auto
-        ( long "minconn"
-        <> short 'c'
-        <> metavar "MINIMUM_CONNECTIONS" )))
+        ( long "minincomingconn"
+        <> short 'i'
+        <> metavar "MINIMUM_INCOMING_CONNECTIONS" )))
+    <*> (minThreshold <$> optional ( option auto
+        ( long "minoutgoingconn"
+        <> short 'o'
+        <> metavar "MINIMUM_OUTGOING_CONNECTIONS" )))

--- a/lib/Nagios/Check/RabbitMQ/Options.hs
+++ b/lib/Nagios/Check/RabbitMQ/Options.hs
@@ -36,4 +36,4 @@ checkOptions = CheckOptions
     <*> (minThreshold <$> optional ( option auto
         ( long "minconn"
         <> short 'c'
-        <> metavar "MAXIMUM_CONNECTIONS" )))
+        <> metavar "MINIMUM_CONNECTIONS" )))

--- a/lib/Nagios/Check/RabbitMQ/Options.hs
+++ b/lib/Nagios/Check/RabbitMQ/Options.hs
@@ -1,13 +1,10 @@
 module Nagios.Check.RabbitMQ.Options where
 
 import           Nagios.Check.RabbitMQ.Types
-
 import           Options.Applicative
-
 
 parseOptions :: IO CheckOptions
 parseOptions = execParser optionParser
-
 
 optionParser :: ParserInfo CheckOptions
 optionParser =
@@ -29,18 +26,14 @@ checkOptions = CheckOptions
         <> short 'e'
         <> help "Name of the exchange to check")
     <*> (minThreshold <$> optional ( option auto
-        ( long "minwarning"
-        <> short 'w'
-        <> metavar "MINIMUM_WARN" )))
+        ( long "minrate"
+        <> short 'r'
+        <> metavar "MINIMUM_RATE" )))
+    <*> (maxThreshold <$> optional ( option auto
+        ( long "maxrate"
+        <> short 'R'
+        <> metavar "MAXIMUM_RATE" )))
     <*> (minThreshold <$> optional ( option auto
-        ( long "mincritical"
+        ( long "minconn"
         <> short 'c'
-        <> metavar "MINIMUM_CRIT" )))
-    <*> (maxThreshold <$> optional ( option auto
-        ( long "maxwarning"
-        <> short 'W'
-        <> metavar "MAXIMUM_WARN" )))
-    <*> (maxThreshold <$> optional ( option auto
-        ( long "maxcritical"
-        <> short 'C'
-        <> metavar "MAXIMUM_CRIT" )))
+        <> metavar "MAXIMUM_CONNECTIONS" )))

--- a/lib/Nagios/Check/RabbitMQ/Types.hs
+++ b/lib/Nagios/Check/RabbitMQ/Types.hs
@@ -5,10 +5,6 @@ module Nagios.Check.RabbitMQ.Types where
 
 import           Control.Applicative
 import           Data.Aeson
-import qualified Data.ByteString.Char8 as BSC
-import           Data.Int
-import           Data.Text             (Text)
-import qualified Data.Text             as T
 import           GHC.Generics
 
 data Threshold = NoThreshold
@@ -53,11 +49,10 @@ data MessageDetail = MessageDetail
     , connectionsOutgoing :: [ConnectionDetail]
     } deriving (Show,Generic)
 
-
 instance FromJSON MessageDetail where
     parseJSON (Object o) = MessageDetail
 	<$> ((o .: "message_stats") >>= (.: "confirm_details") >>= (.: "avg_rate"))
 	<*> ((o .: "message_stats") >>= (.: "publish_in_details") >>= (.: "avg_rate"))
 	<*> ((o .: "message_stats") >>= (.: "publish_out_details") >>= (.: "avg_rate"))
-	<*> ((o .: "incoming"))
-	<*> ((o .: "outgoing"))
+	<*> (o .: "incoming")
+	<*> (o .: "outgoing")

--- a/lib/Nagios/Check/RabbitMQ/Types.hs
+++ b/lib/Nagios/Check/RabbitMQ/Types.hs
@@ -49,6 +49,7 @@ data MessageDetail = MessageDetail
     , connectionsOutgoing :: [ConnectionDetail]
     } deriving (Show,Generic)
 
+-- Average rate based on the query parameters from the api call
 instance FromJSON MessageDetail where
     parseJSON (Object o) = MessageDetail
 	<$> ((o .: "message_stats") >>= (.: "confirm_details") >>= (.: "avg_rate"))

--- a/lib/Nagios/Check/RabbitMQ/Types.hs
+++ b/lib/Nagios/Check/RabbitMQ/Types.hs
@@ -38,14 +38,26 @@ data CheckOptions = CheckOptions
     , maxCritical :: Threshold
     } deriving Show
 
+data ConnectionDetail = ConnectionDetail
+    { publish :: Double } deriving (Show, Generic)
+
+instance FromJSON ConnectionDetail where
+    parseJSON (Object o) = ConnectionDetail
+         <$> ((o .: "stats") >>= (.: "publish"))
+
 data MessageDetail = MessageDetail
-    { rateConfirms   :: Double
-    , ratePublishIn  :: Double
-    , ratePublishOut :: Double
+    { rateConfirms        :: Double
+    , ratePublishIn       :: Double
+    , ratePublishOut      :: Double
+    , connectionsIncoming :: [ConnectionDetail]
+    , connectionsOutgoing :: [ConnectionDetail]
     } deriving (Show,Generic)
+
 
 instance FromJSON MessageDetail where
     parseJSON (Object o) = MessageDetail
-                        <$> ((o .: "message_stats") >>= (.: "confirm_details") >>= (.: "avg_rate"))
-                        <*> ((o .: "message_stats") >>= (.: "publish_in_details") >>= (.: "avg_rate"))
-                        <*> ((o .: "message_stats") >>= (.: "publish_out_details") >>= (.: "avg_rate"))
+	<$> ((o .: "message_stats") >>= (.: "confirm_details") >>= (.: "avg_rate"))
+	<*> ((o .: "message_stats") >>= (.: "publish_in_details") >>= (.: "avg_rate"))
+	<*> ((o .: "message_stats") >>= (.: "publish_out_details") >>= (.: "avg_rate"))
+	<*> ((o .: "incoming"))
+	<*> ((o .: "outgoing"))

--- a/lib/Nagios/Check/RabbitMQ/Types.hs
+++ b/lib/Nagios/Check/RabbitMQ/Types.hs
@@ -26,12 +26,11 @@ maxThreshold Nothing  = NoThreshold
 maxThreshold (Just x) = MinThreshold x
 
 data CheckOptions = CheckOptions
-    { hostname    :: String
-    , exchange    :: String
-    , minWarning  :: Threshold
-    , minCritical :: Threshold
-    , maxWarning  :: Threshold
-    , maxCritical :: Threshold
+    { hostname :: String
+    , exchange :: String
+    , minRate  :: Threshold
+    , maxRate  :: Threshold
+    , minConn  :: Threshold
     } deriving Show
 
 data ConnectionDetail = ConnectionDetail

--- a/lib/Nagios/Check/RabbitMQ/Types.hs
+++ b/lib/Nagios/Check/RabbitMQ/Types.hs
@@ -26,11 +26,12 @@ maxThreshold Nothing  = NoThreshold
 maxThreshold (Just x) = MinThreshold x
 
 data CheckOptions = CheckOptions
-    { hostname :: String
-    , exchange :: String
-    , minRate  :: Threshold
-    , maxRate  :: Threshold
-    , minConn  :: Threshold
+    { hostname         :: String
+    , exchange         :: String
+    , minRate          :: Threshold
+    , maxRate          :: Threshold
+    , minIncomingConn  :: Threshold
+    , minOutgoingConn  :: Threshold
     } deriving Show
 
 data ConnectionDetail = ConnectionDetail

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -45,15 +45,20 @@ main = runNagiosPlugin $ do
 	    simplePerfDatum "rateConfirms"        $ RealValue rateConfirms
 	    simplePerfDatum "ratePublishIn"       $ RealValue ratePublishIn
 	    simplePerfDatum "ratePublishOut"      $ RealValue ratePublishOut
-	    simplePerfDatum "connectionsIncoming" $ IntegralValue . fromIntegral $ length connectionsIncoming
-	    simplePerfDatum "connectionsOutgoing" $ IntegralValue . fromIntegral $ length connectionsOutgoing
+
+            let countIncoming = length connectionsIncoming
+            let countOutgoing = length connectionsOutgoing
+
+	    simplePerfDatum "connectionsIncoming" $ IntegralValue . fromIntegral $ countIncoming
+	    simplePerfDatum "connectionsOutgoing" $ IntegralValue . fromIntegral $ countOutgoing
 
 	    --- Check options, if available
-	    unless (rateConfirms `inBoundsOf` minWarning &&
-		    rateConfirms `inBoundsOf` maxWarning)
-		   (addResult Warning "Confirm Rate out of bounds")
-
-	    unless (rateConfirms `inBoundsOf` minCritical &&
-		    rateConfirms `inBoundsOf` maxCritical)
+	    unless (rateConfirms `inBoundsOf` minRate && rateConfirms `inBoundsOf` maxRate)
 		   (addResult Critical "Confirm Rate out of bounds")
+
+	    unless (fromIntegral countIncoming `inBoundsOf` minConn)
+	           (addResult Critical "Incoming connection rate out of bounds")
+
+	    unless (fromIntegral countOutgoing `inBoundsOf` minConn)
+	           (addResult Critical "Outgoing connection rate out of bounds")
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -42,11 +42,11 @@ main = runNagiosPlugin $ do
         Right MessageDetail{..} -> do
 	    addResult OK "Exchange rate within bounds"
 
-	    simplePerfDatum "rateConfirms"        (RealValue rateConfirms)
-	    simplePerfDatum "ratePublishIn"       (RealValue ratePublishIn)
-	    simplePerfDatum "ratePublishOut"      (RealValue ratePublishOut)
-	    simplePerfDatum "connectionsIncoming" (IntegralValue (fromIntegral (length connectionsIncoming)))
-	    simplePerfDatum "connectionsOutgoing" (IntegralValue (fromIntegral (length connectionsOutgoing)))
+	    simplePerfDatum "rateConfirms"        $ RealValue rateConfirms
+	    simplePerfDatum "ratePublishIn"       $ RealValue ratePublishIn
+	    simplePerfDatum "ratePublishOut"      $ RealValue ratePublishOut
+	    simplePerfDatum "connectionsIncoming" $ IntegralValue . fromIntegral $ length connectionsIncoming
+	    simplePerfDatum "connectionsOutgoing" $ IntegralValue . fromIntegral $ length connectionsOutgoing
 
 	    --- Check options, if available
 	    unless (rateConfirms `inBoundsOf` minWarning &&

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -56,9 +56,9 @@ main = runNagiosPlugin $ do
 	    unless (rateConfirms `inBoundsOf` minRate && rateConfirms `inBoundsOf` maxRate)
 		   (addResult Critical "Confirm Rate out of bounds")
 
-	    unless (fromIntegral countIncoming `inBoundsOf` minConn)
+	    unless (fromIntegral countIncoming `inBoundsOf` minIncomingConn)
 	           (addResult Critical "Incoming connection rate out of bounds")
 
-	    unless (fromIntegral countOutgoing `inBoundsOf` minConn)
+	    unless (fromIntegral countOutgoing `inBoundsOf` minOutgoingConn)
 	           (addResult Critical "Outgoing connection rate out of bounds")
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,18 +4,14 @@
 module Main where
 
 import           Control.Applicative
-import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Trans
 import           Data.Aeson
 import qualified Data.ByteString.Char8 as BSC
-import           Data.Maybe
-import           Data.Monoid
 import qualified Data.Text             as T
 import           Nagios.Check.RabbitMQ
 import           Network.HTTP.Client
 import           System.Environment
-import           System.Exit
 import           System.Nagios.Plugin
 
 simplePerfDatum :: T.Text -> PerfValue -> NagiosPlugin()
@@ -23,7 +19,7 @@ simplePerfDatum n p = addPerfDatum n p NullUnit Nothing Nothing Nothing Nothing
 
 main :: IO ()
 main = runNagiosPlugin $ do
-    CheckOptions{..} <- liftIO $ parseOptions
+    CheckOptions{..} <- liftIO parseOptions
 
     username <- liftIO $ maybe "" BSC.pack <$> lookupEnv "RABBIT_USER"
     password <- liftIO $ maybe "" BSC.pack <$> lookupEnv "RABBIT_PASS"


### PR DESCRIPTION
Use the count of the "incoming" and "outgoing" sub-tree in the main API call to count the incoming and outgoing connections

Previously the logic was to count the connections for the entire installation, but this makes no sense in the context of a single exchange within the installation. 
